### PR TITLE
feat: Add frontend authentication

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,22 +1,32 @@
 import { useEffect, useState } from "react"
+import { useAuth } from "./contexts/AuthContext"
+import { Login } from "./components/Login"
 
 function App() {
-  const [count, setCount] = useState(0)
+  const { isAuthenticated, user, logout } = useAuth()
+  const [count, setCount] = useState<number>(0)
 
   useEffect(() => {
-    fetch("/api")
-      .then((res) => {
-        if (!res.ok) throw new Error(`HTTP error! Status: ${res.status}`)
-        return res.json()
-      })
-      .then((data) => setCount(data.count))
-      .catch((err) => console.error("Failed to fetch count:", err))
-  }, [])
+    if (isAuthenticated) {
+      fetch("/api")
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP error! Status: ${res.status}`)
+          return res.json()
+        })
+        .then((data) => setCount(data.count))
+        .catch((err) => console.error("Failed to fetch count:", err))
+    }
+  }, [isAuthenticated])
+
+  if (!isAuthenticated) {
+    return <Login />
+  }
 
   return (
     <div>
-      <h1>Hello World!</h1>
+      <h1>Hello {user?.username}!</h1>
       <p>I have been seen {count !== 0 ? count : "loading..."} times.</p>
+      <button onClick={logout}>Logout</button>
     </div>
   )
 }

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+
+export function Login() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const { login } = useAuth()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await login(username, password)
+    } catch (err) {
+      setError('Login failed')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <div>
+        <label>
+          Username:
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Password:
+          <input
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+      </div>
+      <button type="submit">Login</button>
+    </form>
+  )
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+interface User {
+  username: string
+  created_at: string
+}
+
+interface AuthContextType {
+  user: User | null
+  login: (username: string, password: string) => Promise<void>
+  logout: () => void
+  isAuthenticated: boolean
+}
+
+const AuthContext = createContext<AuthContextType | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+
+  const login = async (username: string, password: string) => {
+    const response = await fetch('/api/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ username, password }),
+    })
+
+    if (!response.ok) {
+      throw new Error('Login failed')
+    }
+
+    const data = await response.json()
+    setUser(data.user)
+  }
+
+  const logout = () => {
+    setUser(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{
+      user,
+      login,
+      logout,
+      isAuthenticated: !!user
+    }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { AuthProvider } from './contexts/AuthContext'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
- Adds authentication helpers to the frontend and uses them to show a login page to unauthenticated users
- Adds a `/login` route to the backend which authenticates a user's credentials
- Shows the logged in user's name on the visit counter page

Note that this isn't quite secure yet as the login only returns the user's details which can't be used as a way to verify the user is authenticated for future requests. We'll address this in the next change by using token-based authentication.

### Login Page
<img width="686" alt="image" src="https://github.com/user-attachments/assets/34d46c6b-e81f-45b3-bc30-2efd5a113c8d" />

### Counter Page
<img width="686" alt="image" src="https://github.com/user-attachments/assets/8e11b5ed-189a-4f97-9a52-1a2b19c03eed" />
