### PR TITLE
feat: Use token-based authentication

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/lib/pq v1.10.9
 	golang.org/x/crypto v0.21.0
 )
+
+require github.com/golang-jwt/jwt/v5 v5.2.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,3 +1,5 @@
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,24 +1,33 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"html/template"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	_ "github.com/lib/pq"
 	"golang.org/x/crypto/bcrypt"
 )
 
 var db *sql.DB
 var tmpl *template.Template
+var jwtKey = []byte("your-secret-key")
 
 type User struct {
 	Username  string    `json:"username"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+type Claims struct {
+	Username string `json:"username"`
+	jwt.RegisteredClaims
 }
 
 type LoginRequest struct {
@@ -27,7 +36,8 @@ type LoginRequest struct {
 }
 
 type LoginResponse struct {
-	User User `json:"user"`
+	Token string `json:"token"`
+	User  User   `json:"user"`
 }
 
 func init() {
@@ -41,12 +51,45 @@ func init() {
 	tmpl = template.Must(template.ParseFiles("templates/admin.html"))
 }
 
-func loginHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
+func generateToken(username string) (string, error) {
+	expirationTime := time.Now().Add(24 * time.Hour)
+	claims := &Claims{
+		Username: username,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expirationTime),
+		},
 	}
 
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(jwtKey)
+}
+
+func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			http.Error(w, "Authorization header required", http.StatusUnauthorized)
+			return
+		}
+
+		tokenString := strings.Replace(authHeader, "Bearer ", "", 1)
+		claims := &Claims{}
+
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(t *jwt.Token) (interface{}, error) {
+			return jwtKey, nil
+		})
+
+		if err != nil || !token.Valid {
+			http.Error(w, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), "username", claims.Username)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	}
+}
+
+func loginHandler(w http.ResponseWriter, r *http.Request) {
 	var req LoginRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
@@ -60,22 +103,28 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 		req.Username,
 	).Scan(&storedHash, &user.Username, &user.CreatedAt)
 
-	if err != nil {
-		if err == sql.ErrNoRows {
-			http.Error(w, "Invalid credentials", http.StatusUnauthorized)
-			return
-		}
-		http.Error(w, "Database error", http.StatusInternalServerError)
-		return
-	}
-
-	if err := bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(req.Password)); err != nil {
+	if err != nil || bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(req.Password)) != nil {
 		http.Error(w, "Invalid credentials", http.StatusUnauthorized)
 		return
 	}
 
+	token, err := generateToken(user.Username)
+	if err != nil {
+		http.Error(w, "Error generating token", http.StatusInternalServerError)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(LoginResponse{User: user})
+	json.NewEncoder(w).Encode(LoginResponse{
+		Token: token,
+		User:  user,
+	})
+}
+
+func verifyHandler(w http.ResponseWriter, r *http.Request) {
+	// This will be wrapped by authMiddleware which verifies the token so
+	//this just returns 200 OK to indicate token is valid
+	w.WriteHeader(http.StatusOK)
 }
 
 func viewCountHandler(w http.ResponseWriter, r *http.Request) {
@@ -201,8 +250,9 @@ func deleteUserHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	http.HandleFunc("/", viewCountHandler)
+	http.HandleFunc("/", authMiddleware(viewCountHandler))
 	http.HandleFunc("/login", loginHandler)
+	http.HandleFunc("/verify", authMiddleware(verifyHandler))
 	http.HandleFunc("/admin", basicAuth(adminHandler))
 	http.HandleFunc("/admin/users", basicAuth(createUserHandler))
 	http.HandleFunc("/admin/users/delete", basicAuth(deleteUserHandler))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,19 +3,25 @@ import { useAuth } from "./contexts/AuthContext"
 import { Login } from "./components/Login"
 
 function App() {
-  const { isAuthenticated, user, logout } = useAuth()
+  const { isAuthenticated, user, logout, authFetch } = useAuth()
   const [count, setCount] = useState<number>(0)
 
   useEffect(() => {
     if (isAuthenticated) {
-      fetch("/api")
+      authFetch("/api")
         .then((res) => {
           if (!res.ok) throw new Error(`HTTP error! Status: ${res.status}`)
           return res.json()
         })
         .then((data) => setCount(data.count))
-        .catch((err) => console.error("Failed to fetch count:", err))
-    }
+        .then(data => setCount(data.count))
+                .catch(err => {
+                  console.error("Failed to fetch count:", err)
+                  if (err.message === 'Session expired') {
+                    logout()
+                  }
+                })
+            }
   }, [isAuthenticated])
 
   if (!isAuthenticated) {


### PR DESCRIPTION
Uses a JSON Web Token (JWT) from the backend to authenticate requests to the backend requiring the user to be logged in.

# Testing
Tested that I could log in to the frontend and that refreshing the page kept me logged in.

Also tested the backend manually using cURL.

1. Get a JWT with the default admin credentials:
```sh
curl -X POST http://localhost:8080/login \
-H "Content-Type: application/json" \
-d '{"username": "admin", "password": "your_secure_password"}'
```

This returns a response like
```json
{
  "token": "eyJhbGciO...G2sggkcA",
  "user": {
    "username": "yourusername",
    "created_at": "2025-02-28T05:12:00.970234Z"
  }
}
```
2. Test the root endpoint:
```sh
curl http://localhost:8080/ \
-H "Authorization: Bearer eyJhbGciO...G2sggkcA"
```

3. Test the `verify` endpoint:
```sh
curl -i http://localhost:8080/verify \
-H "Authorization: Bearer eyJhbGciO...G2sggkcA"
```

The `-i` (include headers) flag will show the 200 response.

4. Test with an invalid token:
```sh
curl http://localhost:8080/ \
-H "Authorization: Bearer eyJhbGciO...abcdefgh"
```

5. Test without a token:
```sh
curl http://localhost:8080/
```
