### PR TITLE
feat: Add sign-up page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react"
 import { useAuth } from "./contexts/AuthContext"
 import { Login } from "./components/Login"
+import { SignUp } from "./components/SignUp"
 
 function App() {
   const { isAuthenticated, user, logout, authFetch } = useAuth()
   const [count, setCount] = useState<number>(0)
+  const [showSignUp, setShowSignUp] = useState(false)
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -24,7 +26,27 @@ function App() {
   }, [isAuthenticated, authFetch, logout])
 
   if (!isAuthenticated) {
-    return <Login />
+    return (
+      <div>
+        {showSignUp ? (
+          <>
+            <SignUp />
+            <p>
+              Already have an account?{" "}
+              <button onClick={() => setShowSignUp(false)}>Log in</button>
+            </p>
+          </>
+        ) : (
+          <>
+            <Login />
+            <p>
+              Don't have an account?{" "}
+              <button onClick={() => setShowSignUp(true)}>Sign up</button>
+            </p>
+          </>
+        )}
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/components/SignUp.tsx
+++ b/frontend/src/components/SignUp.tsx
@@ -1,19 +1,19 @@
 import { useState } from 'react'
 import { useAuth } from '../contexts/AuthContext'
 
-export function Login() {
+export function SignUp() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
-  const { login } = useAuth()
+  const { signup } = useAuth()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
-      await login(username, password)
+      await signup(username, password)
     } catch (err) {
       console.log(err)
-      setError('Login failed')
+      setError('Registration failed')
     }
   }
 
@@ -35,13 +35,13 @@ export function Login() {
           Password:
           <input
             type="password"
-            autoComplete="current-password"
+            autoComplete="new-password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
           />
         </label>
       </div>
-      <button type="submit">Login</button>
+      <button type="submit">Sign Up</button>
     </form>
   )
 }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -13,6 +13,7 @@ interface AuthState {
 interface AuthContextType {
   user: User | null
   login: (username: string, password: string) => Promise<void>
+  signup: (username: string, password: string) => Promise<void>
   logout: () => void
   isAuthenticated: boolean
   authFetch: (url: string, options?: RequestInit) => Promise<Response>
@@ -41,7 +42,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         logout()
       })
     }
-  }, [])
+  }, [state.token])
 
   const login = async (username: string, password: string) => {
     const response = await fetch('/api/login', {
@@ -52,6 +53,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (!response.ok) {
       throw new Error('Login failed')
+    }
+
+    const { token, user } = await response.json()
+    localStorage.setItem('token', token)
+    localStorage.setItem('user', JSON.stringify(user))
+    setState({ user, token })
+  }
+
+  const signup = async (username: string, password: string) => {
+    const response = await fetch('/api/signup', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ username, password }),
+    })
+
+    if (!response.ok) {
+      throw new Error('Signup failed')
     }
 
     const { token, user } = await response.json()
@@ -90,6 +110,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       user: state.user,
       isAuthenticated: !!state.token,
       login,
+      signup,
       logout,
       authFetch
     }}>


### PR DESCRIPTION
Lets users sign-up for an account through the web UI, previously this was only possible through the admin UI.

- Adds `signupHandler` to the backend which creates a user if one doesn't already exist
- Adds a `SignUp` component and a button on the main page which uses it to sign users up

#### Sign-Up Page
<img width="686" alt="image" src="https://github.com/user-attachments/assets/beae9dd7-3d45-4697-b099-4378908cfdb0" />

#### Post Sign-Up
<img width="686" alt="image" src="https://github.com/user-attachments/assets/981399ed-c760-41c1-bd11-4d540da7de01" />

#### Failed Sign-Up
<img width="686" alt="image" src="https://github.com/user-attachments/assets/1f4452e6-3eda-43d1-b7e3-0bd34323107f" />
