### PR TITLE
refactor: Organize backend into separate modules

### DIFF
--- a/backend/admin/handlers.go
+++ b/backend/admin/handlers.go
@@ -1,0 +1,95 @@
+package admin
+
+import (
+	"database/sql"
+	"html/template"
+	"net/http"
+
+	"github.com/kujacorp/checklist/types"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type Handler struct {
+    DB   *sql.DB
+    Tmpl *template.Template
+}
+
+func NewHandler(db *sql.DB, tmpl *template.Template) *Handler {
+    return &Handler{DB: db, Tmpl: tmpl}
+}
+
+func (h *Handler) AdminHandler(w http.ResponseWriter, r *http.Request) {
+    data := struct {
+        Users       []types.User
+        Message     string
+        MessageType string
+    }{}
+
+    rows, err := h.DB.Query("SELECT username, created_at FROM users ORDER BY created_at")
+    if err != nil {
+        http.Error(w, "Database error", http.StatusInternalServerError)
+        return
+    }
+    defer rows.Close()
+
+    for rows.Next() {
+        var user types.User
+        if err := rows.Scan(&user.Username, &user.CreatedAt); err != nil {
+            continue
+        }
+        data.Users = append(data.Users, user)
+    }
+
+    h.Tmpl.Execute(w, data)
+}
+
+func (h *Handler) CreateUserHandler(w http.ResponseWriter, r *http.Request) {
+    if r.Method != http.MethodPost {
+        http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+        return
+    }
+
+    username := r.FormValue("username")
+    password := r.FormValue("password")
+
+    if username == "" || password == "" {
+        http.Error(w, "Username and password required", http.StatusBadRequest)
+        return
+    }
+
+    hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+    if err != nil {
+        http.Error(w, "Error processing password", http.StatusInternalServerError)
+        return
+    }
+
+    _, err = h.DB.Exec("INSERT INTO users (username, password_hash) VALUES ($1, $2)",
+        username, string(hashedPassword))
+    if err != nil {
+        http.Error(w, "Error creating user", http.StatusInternalServerError)
+        return
+    }
+
+    http.Redirect(w, r, "/admin", http.StatusSeeOther)
+}
+
+func (h *Handler) DeleteUserHandler(w http.ResponseWriter, r *http.Request) {
+    if r.Method != http.MethodPost {
+        http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+        return
+    }
+
+    username := r.FormValue("username")
+    if username == "admin" {
+        http.Error(w, "Cannot delete admin user", http.StatusBadRequest)
+        return
+    }
+
+    _, err := h.DB.Exec("DELETE FROM users WHERE username = $1", username)
+    if err != nil {
+        http.Error(w, "Error deleting user", http.StatusInternalServerError)
+        return
+    }
+
+    http.Redirect(w, r, "/admin", http.StatusSeeOther)
+}

--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+
+	"github.com/kujacorp/checklist/auth"
+	"github.com/kujacorp/checklist/types"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type Handler struct {
+    DB     *sql.DB
+    JWTKey []byte
+}
+
+func NewHandler(db *sql.DB, jwtKey []byte) *Handler {
+    return &Handler{DB: db, JWTKey: jwtKey}
+}
+
+func (h *Handler) LoginHandler(w http.ResponseWriter, r *http.Request) {
+    var req types.LoginRequest
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, "Invalid request body", http.StatusBadRequest)
+        return
+    }
+
+    var storedHash string
+    var user types.User
+    err := h.DB.QueryRow(
+        "SELECT password_hash, username, created_at FROM users WHERE username = $1",
+        req.Username,
+    ).Scan(&storedHash, &user.Username, &user.CreatedAt)
+
+    if err != nil || bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(req.Password)) != nil {
+        http.Error(w, "Invalid credentials", http.StatusUnauthorized)
+        return
+    }
+
+    token, err := auth.GenerateToken(user.Username, h.JWTKey)
+    if err != nil {
+        http.Error(w, "Error generating token", http.StatusInternalServerError)
+        return
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(types.LoginResponse{
+        Token: token,
+        User:  user,
+    })
+}
+
+func (h *Handler) SignupHandler(w http.ResponseWriter, r *http.Request) {
+    var req types.SignupRequest
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        http.Error(w, "Invalid request body", http.StatusBadRequest)
+        return
+    }
+
+    var exists bool
+    err := h.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM users WHERE username = $1)",
+        req.Username).Scan(&exists)
+    if err != nil {
+        http.Error(w, "Database error", http.StatusInternalServerError)
+        return
+    }
+    if exists {
+        http.Error(w, "Username already taken", http.StatusConflict)
+        return
+    }
+
+    hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+    if err != nil {
+        http.Error(w, "Error processing password", http.StatusInternalServerError)
+        return
+    }
+
+    var user types.User
+    err = h.DB.QueryRow(
+        "INSERT INTO users (username, password_hash) VALUES ($1, $2) RETURNING username, created_at",
+        req.Username, string(hashedPassword),
+    ).Scan(&user.Username, &user.CreatedAt)
+    if err != nil {
+        http.Error(w, "Error creating user", http.StatusInternalServerError)
+        return
+    }
+
+    token, err := auth.GenerateToken(user.Username, h.JWTKey)
+    if err != nil {
+        http.Error(w, "Error generating token", http.StatusInternalServerError)
+        return
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(types.LoginResponse{
+        Token: token,
+        User:  user,
+    })
+}
+
+func (h *Handler) VerifyHandler(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) ViewCountHandler(w http.ResponseWriter, r *http.Request) {
+    var count int
+    err := h.DB.QueryRow("SELECT COUNT(*) FROM visits").Scan(&count)
+    if err != nil {
+        http.Error(w, "Failed to get visit count", http.StatusInternalServerError)
+        return
+    }
+    count++
+    _, _ = h.DB.Exec("INSERT INTO visits DEFAULT VALUES")
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(map[string]int{"count": count})
+}

--- a/backend/auth/jwt.go
+++ b/backend/auth/jwt.go
@@ -1,0 +1,21 @@
+package auth
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/kujacorp/checklist/types"
+)
+
+func GenerateToken(username string, jwtKey []byte) (string, error) {
+    expirationTime := time.Now().Add(24 * time.Hour)
+    claims := &types.Claims{
+        Username: username,
+        RegisteredClaims: jwt.RegisteredClaims{
+            ExpiresAt: jwt.NewNumericDate(expirationTime),
+        },
+    }
+
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+    return token.SignedString(jwtKey)
+}

--- a/backend/auth/middleware.go
+++ b/backend/auth/middleware.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/kujacorp/checklist/types"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type Middleware struct {
+    DB     *sql.DB
+    JWTKey []byte
+}
+
+func NewMiddleware(db *sql.DB, jwtKey []byte) *Middleware {
+    return &Middleware{DB: db, JWTKey: jwtKey}
+}
+
+func (m *Middleware) AuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        authHeader := r.Header.Get("Authorization")
+        if authHeader == "" {
+            http.Error(w, "Authorization header required", http.StatusUnauthorized)
+            return
+        }
+
+        tokenString := strings.Replace(authHeader, "Bearer ", "", 1)
+        claims := &types.Claims{}
+
+        token, err := jwt.ParseWithClaims(tokenString, claims, func(t *jwt.Token) (interface{}, error) {
+            return m.JWTKey, nil
+        })
+
+        if err != nil || !token.Valid {
+            http.Error(w, "Invalid token", http.StatusUnauthorized)
+            return
+        }
+
+        ctx := context.WithValue(r.Context(), "username", claims.Username)
+        next.ServeHTTP(w, r.WithContext(ctx))
+    }
+}
+
+func (m *Middleware) BasicAuth(next http.HandlerFunc) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        username, password, ok := r.BasicAuth()
+        if !ok {
+            log.Printf("Auth failed: No basic auth credentials provided (IP: %s)", r.RemoteAddr)
+            w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+            http.Error(w, "Unauthorized", http.StatusUnauthorized)
+            return
+        }
+
+        var storedHash string
+        err := m.DB.QueryRow("SELECT password_hash FROM users WHERE username = $1", username).Scan(&storedHash)
+        if err != nil {
+            log.Printf("Auth failed: User '%s' not found (IP: %s)", username, r.RemoteAddr)
+            w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+            http.Error(w, "Unauthorized", http.StatusUnauthorized)
+            return
+        }
+
+        if err := bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(password)); err != nil {
+            log.Printf("Auth failed: Invalid password for user '%s' (IP: %s)", username, r.RemoteAddr)
+            w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+            http.Error(w, "Unauthorized", http.StatusUnauthorized)
+            return
+        }
+
+        next.ServeHTTP(w, r)
+    }
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,4 +1,4 @@
-module checklist
+module github.com/kujacorp/checklist
 
 go 1.24.0
 

--- a/backend/types/types.go
+++ b/backend/types/types.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type User struct {
+    Username  string    `json:"username"`
+    CreatedAt time.Time `json:"created_at"`
+}
+
+type Claims struct {
+    Username string `json:"username"`
+    jwt.RegisteredClaims
+}
+
+type LoginRequest struct {
+    Username string `json:"username"`
+    Password string `json:"password"`
+}
+
+type LoginResponse struct {
+    Token string `json:"token"`
+    User  User   `json:"user"`
+}
+
+type SignupRequest struct {
+    Username string `json:"username"`
+    Password string `json:"password"`
+}


### PR DESCRIPTION
Separates out auth, admin, and API functionality into their own modules.
- Puts shared types into a `types` package
- Puts admin handlers into an `admin` package
- Puts API handlers into an `api` package

Uses top level `Handler` types in API and Admin to handle shared data between the different handlers.

Note this leaves dead code in `main.go` which we'll delete in a future PR as cleanup.

# Testing
Went through login, signup, and seeing the view count on the frontend. Confirmed user creation and deletion still work in the admin page.