### PR TITLE
feat: Add backend for todo lists

### DIFF
--- a/backend/api/handlers.go
+++ b/backend/api/handlers.go
@@ -4,6 +4,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/kujacorp/checklist/auth"
 	"github.com/kujacorp/checklist/types"
@@ -115,4 +118,538 @@ func (h *Handler) ViewCountHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]int{"count": count})
+}
+
+func (h *Handler) GetListsHandler(w http.ResponseWriter, r *http.Request) {
+	username := r.Context().Value("username").(string)
+
+	rows, err := h.DB.Query(`
+		SELECT id, title, description, created_at, updated_at
+		FROM todo_lists
+		WHERE username = $1
+		ORDER BY created_at DESC`, username)
+	if err != nil {
+		http.Error(w, "Failed to fetch todo lists", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	var lists []types.TodoList
+	for rows.Next() {
+		var list types.TodoList
+		if err := rows.Scan(&list.ID, &list.Title, &list.Description, &list.CreatedAt, &list.UpdatedAt); err != nil {
+			continue
+		}
+		list.Username = username
+		lists = append(lists, list)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(lists)
+}
+
+func (h *Handler) GetListHandler(w http.ResponseWriter, r *http.Request) {
+	username := r.Context().Value("username").(string)
+
+	// Extract list ID from the path
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 {
+		http.Error(w, "Invalid list ID", http.StatusBadRequest)
+		return
+	}
+
+	listID, err := strconv.Atoi(pathParts[len(pathParts)-1])
+	if err != nil {
+		http.Error(w, "Invalid list ID", http.StatusBadRequest)
+		return
+	}
+
+	var list types.TodoList
+	err = h.DB.QueryRow(`
+		SELECT id, title, description, created_at, updated_at
+		FROM todo_lists
+		WHERE id = $1 AND username = $2`, listID, username).Scan(
+		&list.ID, &list.Title, &list.Description, &list.CreatedAt, &list.UpdatedAt)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			http.Error(w, "Todo list not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "Database error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	list.Username = username
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(list)
+}
+
+func (h *Handler) CreateListHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	username := r.Context().Value("username").(string)
+
+	var req types.TodoListCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Title == "" {
+		http.Error(w, "Title is required", http.StatusBadRequest)
+		return
+	}
+
+	var list types.TodoList
+	err := h.DB.QueryRow(`
+		INSERT INTO todo_lists (username, title, description)
+		VALUES ($1, $2, $3)
+		RETURNING id, title, description, created_at, updated_at`,
+		username, req.Title, req.Description).Scan(
+		&list.ID, &list.Title, &list.Description, &list.CreatedAt, &list.UpdatedAt)
+
+	if err != nil {
+		http.Error(w, "Failed to create todo list", http.StatusInternalServerError)
+		return
+	}
+
+	list.Username = username
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(list)
+}
+
+func (h *Handler) UpdateListHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut && r.Method != http.MethodPatch {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	username := r.Context().Value("username").(string)
+
+	// Extract list ID from the path
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 {
+		http.Error(w, "Invalid list ID", http.StatusBadRequest)
+		return
+	}
+
+	listID, err := strconv.Atoi(pathParts[len(pathParts)-1])
+	if err != nil {
+		http.Error(w, "Invalid list ID", http.StatusBadRequest)
+		return
+	}
+
+	var req types.TodoListUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Title == "" {
+		http.Error(w, "Title is required", http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now()
+
+	var list types.TodoList
+	err = h.DB.QueryRow(`
+		UPDATE todo_lists
+		SET title = $1, description = $2, updated_at = $3
+		WHERE id = $4 AND username = $5
+		RETURNING id, title, description, created_at, updated_at`,
+		req.Title, req.Description, now, listID, username).Scan(
+		&list.ID, &list.Title, &list.Description, &list.CreatedAt, &list.UpdatedAt)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			http.Error(w, "Todo list not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "Failed to update todo list", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	list.Username = username
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(list)
+}
+
+func (h *Handler) DeleteListHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	username := r.Context().Value("username").(string)
+
+	// Extract list ID from the path
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 {
+		http.Error(w, "Invalid list ID", http.StatusBadRequest)
+		return
+	}
+
+	listID, err := strconv.Atoi(pathParts[len(pathParts)-1])
+	if err != nil {
+		http.Error(w, "Invalid list ID", http.StatusBadRequest)
+		return
+	}
+
+	// Check if the list exists and belongs to the user
+	var exists bool
+	err = h.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM todo_lists WHERE id = $1 AND username = $2)",
+		listID, username).Scan(&exists)
+
+	if err != nil {
+		http.Error(w, "Database error", http.StatusInternalServerError)
+		return
+	}
+
+	if !exists {
+		http.Error(w, "Todo list not found", http.StatusNotFound)
+		return
+	}
+
+	// Begin transaction
+	tx, err := h.DB.Begin()
+	if err != nil {
+		http.Error(w, "Database error", http.StatusInternalServerError)
+		return
+	}
+
+	// Delete all todos in the list - this should cascade automatically due to foreign key,
+	// but we're being explicit here
+	_, err = tx.Exec("DELETE FROM todos WHERE list_id = $1", listID)
+	if err != nil {
+		tx.Rollback()
+		http.Error(w, "Failed to delete todos", http.StatusInternalServerError)
+		return
+	}
+
+	// Delete the list itself
+	_, err = tx.Exec("DELETE FROM todo_lists WHERE id = $1 AND username = $2", listID, username)
+	if err != nil {
+		tx.Rollback()
+		http.Error(w, "Failed to delete todo list", http.StatusInternalServerError)
+		return
+	}
+
+	// Commit transaction
+	if err = tx.Commit(); err != nil {
+		http.Error(w, "Failed to commit transaction", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) GetTodosForListHandler(w http.ResponseWriter, r *http.Request) {
+	username := r.Context().Value("username").(string)
+
+	// Extract list ID from the path
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 4 || pathParts[len(pathParts)-2] != "todos" {
+		http.Error(w, "Invalid path", http.StatusBadRequest)
+		return
+	}
+
+	listID, err := strconv.Atoi(pathParts[len(pathParts)-3])
+	if err != nil {
+		http.Error(w, "Invalid list ID", http.StatusBadRequest)
+		return
+	}
+
+	// Check if the list exists and belongs to the user
+	var exists bool
+	err = h.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM todo_lists WHERE id = $1 AND username = $2)",
+		listID, username).Scan(&exists)
+
+	if err != nil {
+		http.Error(w, "Database error", http.StatusInternalServerError)
+		return
+	}
+
+	if !exists {
+		http.Error(w, "Todo list not found", http.StatusNotFound)
+		return
+	}
+
+	rows, err := h.DB.Query(`
+		SELECT id, list_id, title, description, completed, created_at, updated_at
+		FROM todos
+		WHERE list_id = $1 AND username = $2
+		ORDER BY created_at DESC`, listID, username)
+	if err != nil {
+		http.Error(w, "Failed to fetch todos", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	var todos []types.Todo
+	for rows.Next() {
+		var todo types.Todo
+		if err := rows.Scan(&todo.ID, &todo.ListID, &todo.Title, &todo.Description, &todo.Completed, &todo.CreatedAt, &todo.UpdatedAt); err != nil {
+			continue
+		}
+		todos = append(todos, todo)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(todos)
+}
+
+func (h *Handler) GetTodoHandler(w http.ResponseWriter, r *http.Request) {
+	username := r.Context().Value("username").(string)
+
+	// Extract todo ID from the path
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 {
+		http.Error(w, "Invalid todo ID", http.StatusBadRequest)
+		return
+	}
+
+	todoID, err := strconv.Atoi(pathParts[len(pathParts)-1])
+	if err != nil {
+		http.Error(w, "Invalid todo ID", http.StatusBadRequest)
+		return
+	}
+
+	var todo types.Todo
+	err = h.DB.QueryRow(`
+		SELECT id, list_id, title, description, completed, created_at, updated_at
+		FROM todos
+		WHERE id = $1 AND username = $2`, todoID, username).Scan(
+		&todo.ID, &todo.ListID, &todo.Title, &todo.Description, &todo.Completed, &todo.CreatedAt, &todo.UpdatedAt)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			http.Error(w, "Todo not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "Database error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(todo)
+}
+
+func (h *Handler) CreateTodoHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	username := r.Context().Value("username").(string)
+
+	// Extract list ID from the path
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 5 || pathParts[len(pathParts)-2] != "todos" {
+		http.Error(w, "Invalid path", http.StatusBadRequest)
+		return
+	}
+
+	listID, err := strconv.Atoi(pathParts[len(pathParts)-3])
+	if err != nil {
+		http.Error(w, "Invalid list ID", http.StatusBadRequest)
+		return
+	}
+
+	// Check if list exists and belongs to the user
+	var exists bool
+	err = h.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM todo_lists WHERE id = $1 AND username = $2)",
+		listID, username).Scan(&exists)
+
+	if err != nil {
+		http.Error(w, "Database error", http.StatusInternalServerError)
+		return
+	}
+
+	if !exists {
+		http.Error(w, "Todo list not found", http.StatusNotFound)
+		return
+	}
+
+	var req types.TodoCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Title == "" {
+		http.Error(w, "Title is required", http.StatusBadRequest)
+		return
+	}
+
+	var todo types.Todo
+	err = h.DB.QueryRow(`
+		INSERT INTO todos (list_id, username, title, description)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, list_id, title, description, completed, created_at, updated_at`,
+		listID, username, req.Title, req.Description).Scan(
+		&todo.ID, &todo.ListID, &todo.Title, &todo.Description, &todo.Completed, &todo.CreatedAt, &todo.UpdatedAt)
+
+	if err != nil {
+		http.Error(w, "Failed to create todo", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(todo)
+}
+
+func (h *Handler) UpdateTodoHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut && r.Method != http.MethodPatch {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	username := r.Context().Value("username").(string)
+
+	// Extract todo ID from the path
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 {
+		http.Error(w, "Invalid todo ID", http.StatusBadRequest)
+		return
+	}
+
+	todoID, err := strconv.Atoi(pathParts[len(pathParts)-1])
+	if err != nil {
+		http.Error(w, "Invalid todo ID", http.StatusBadRequest)
+		return
+	}
+
+	var req types.TodoUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Title == "" {
+		http.Error(w, "Title is required", http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now()
+
+	var todo types.Todo
+	err = h.DB.QueryRow(`
+		UPDATE todos
+		SET title = $1, description = $2, completed = $3, updated_at = $4
+		WHERE id = $5 AND username = $6
+		RETURNING id, list_id, title, description, completed, created_at, updated_at`,
+		req.Title, req.Description, req.Completed, now, todoID, username).Scan(
+		&todo.ID, &todo.ListID, &todo.Title, &todo.Description, &todo.Completed, &todo.CreatedAt, &todo.UpdatedAt)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			http.Error(w, "Todo not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "Failed to update todo", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(todo)
+}
+
+func (h *Handler) ToggleTodoHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPatch {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	username := r.Context().Value("username").(string)
+
+	// Extract todo ID from the path
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 {
+		http.Error(w, "Invalid todo ID", http.StatusBadRequest)
+		return
+	}
+
+	todoID, err := strconv.Atoi(pathParts[len(pathParts)-2])
+	if err != nil {
+		http.Error(w, "Invalid todo ID", http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now()
+
+	var todo types.Todo
+	err = h.DB.QueryRow(`
+		UPDATE todos
+		SET completed = NOT completed, updated_at = $1
+		WHERE id = $2 AND username = $3
+		RETURNING id, list_id, title, description, completed, created_at, updated_at`,
+		now, todoID, username).Scan(
+		&todo.ID, &todo.ListID, &todo.Title, &todo.Description, &todo.Completed, &todo.CreatedAt, &todo.UpdatedAt)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			http.Error(w, "Todo not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "Failed to toggle todo", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(todo)
+}
+
+func (h *Handler) DeleteTodoHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	username := r.Context().Value("username").(string)
+
+	// Extract todo ID from the path
+	pathParts := strings.Split(r.URL.Path, "/")
+	if len(pathParts) < 3 {
+		http.Error(w, "Invalid todo ID", http.StatusBadRequest)
+		return
+	}
+
+	todoID, err := strconv.Atoi(pathParts[len(pathParts)-1])
+	if err != nil {
+		http.Error(w, "Invalid todo ID", http.StatusBadRequest)
+		return
+	}
+
+	// Check if the todo exists and belongs to the user
+	var exists bool
+	err = h.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM todos WHERE id = $1 AND username = $2)",
+		todoID, username).Scan(&exists)
+
+	if err != nil {
+		http.Error(w, "Database error", http.StatusInternalServerError)
+		return
+	}
+
+	if !exists {
+		http.Error(w, "Todo not found", http.StatusNotFound)
+		return
+	}
+
+	_, err = h.DB.Exec("DELETE FROM todos WHERE id = $1 AND username = $2", todoID, username)
+	if err != nil {
+		http.Error(w, "Failed to delete todo", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/init.sql
+++ b/backend/init.sql
@@ -6,3 +6,26 @@ CREATE TABLE IF NOT EXISTS users (
     password_hash VARCHAR(100) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS todo_lists (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50) NOT NULL REFERENCES users(username) ON DELETE CASCADE,
+    title VARCHAR(100) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS todo_lists_username_idx ON todo_lists(username);
+
+CREATE TABLE IF NOT EXISTS todos (
+    id SERIAL PRIMARY KEY,
+    list_id INTEGER NOT NULL REFERENCES todo_lists(id) ON DELETE CASCADE,
+    title VARCHAR(100) NOT NULL,
+    description TEXT,
+    completed BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS todos_list_id_idx ON todos(list_id);

--- a/backend/types/types.go
+++ b/backend/types/types.go
@@ -30,3 +30,43 @@ type SignupRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
 }
+
+type TodoList struct {
+	ID          int       `json:"id"`
+	Username    string    `json:"username"`
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type TodoListCreateRequest struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+type TodoListUpdateRequest struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+type Todo struct {
+	ID          int       `json:"id"`
+	ListID      int       `json:"list_id"`
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	Completed   bool      `json:"completed"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type TodoCreateRequest struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+type TodoUpdateRequest struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Completed   bool   `json:"completed"`
+}


### PR DESCRIPTION
Adds a bunch of CRUD routes for creating todo lists and todos in the list. Todo lists are associated with users and todos are associated with lists.

We document the tables in further detail as a proper document in #35 which we'll also include here.

## Tables

### users
Stores user authentication and account information.

| Column        | Type         | Description                     |
|---------------|--------------|---------------------------------|
| id            | SERIAL       | Primary key                     |
| username      | VARCHAR(50)  | Unique identifier for the user  |
| password_hash | VARCHAR(100) | Securely stored password hash   |
| created_at    | TIMESTAMP    | Account creation timestamp      |

### todo_lists
Contains the todo lists created by users.

| Column      | Type         | Description                     |
|-------------|--------------|---------------------------------|
| id          | SERIAL       | Primary key                     |
| username    | VARCHAR(50)  | Foreign key to users.username   |
| title       | VARCHAR(100) | List title                      |
| description | TEXT         | Optional list description       |
| created_at  | TIMESTAMP    | Creation timestamp              |
| updated_at  | TIMESTAMP    | Last update timestamp           |

### todos
Individual todo items within lists.

| Column      | Type         | Description                     |
|-------------|--------------|---------------------------------|
| id          | SERIAL       | Primary key                     |
| list_id     | INTEGER      | Foreign key to todo_lists.id    |
| title       | VARCHAR(100) | Todo item title                 |
| description | TEXT         | Optional item description       |
| completed   | BOOLEAN      | Completion status               |
| created_at  | TIMESTAMP    | Creation timestamp              |
| updated_at  | TIMESTAMP    | Last update timestamp           |

## Relationships

```mermaid
erDiagram
    USERS ||--o{ TODO_LISTS : creates
    TODO_LISTS ||--o{ TODOS : contains
```

- Each user can have multiple todo lists
- Each todo list belongs to one user
- Each todo list can have multiple todos
- Each todo belongs to one list
- Deleting a user cascades to delete their lists and todos
- Deleting a list cascades to delete its todos

## Indexes
The following indexes are maintained for query optimization:

- `todo_lists_username_idx`: Optimizes queries filtering by username in todo_lists
- `todos_list_id_idx`: Optimizes queries filtering by list_id in todos
