### PR TITLE
build: Hot reload frontend

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,13 @@ services:
       - "3000:3000"
     depends_on:
       - backend
+    develop:
+        watch:
+          - action: sync
+            path: ./frontend
+            target: /app
+            ignore:
+              - node_modules
 
   postgres:
     image: "postgres:alpine"


### PR DESCRIPTION
Uses Docker Compose Watch to sync file changes into the `frontend` container.

Based on StackOverflow answer for [How to make Hot reload works with dockerized vue3 and vite
](https://stackoverflow.com/a/78468901)

Fixes #19