### PR TITLE
feat: Add shell to interact with backend

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,10 @@ go 1.24.0
 require (
 	github.com/lib/pq v1.10.9
 	golang.org/x/crypto v0.21.0
+	golang.org/x/term v0.18.0
 )
 
-require github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+require (
+	github.com/golang-jwt/jwt/v5 v5.2.1
+	golang.org/x/sys v0.18.0 // indirect
+)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -4,3 +4,7 @@ github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
+golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=

--- a/backend/tools/client.go
+++ b/backend/tools/client.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/term"
+)
+
+type LoginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type LoginResponse struct {
+	Token string `json:"token"`
+	User  struct {
+		Username  string `json:"username"`
+		CreatedAt string `json:"created_at"`
+	} `json:"user"`
+}
+
+type ViewCountResponse struct {
+	Count int `json:"count"`
+}
+
+var authToken string
+
+func authenticate() error {
+	fmt.Print("Username: ")
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
+	username := strings.TrimSpace(scanner.Text())
+
+	fmt.Print("Password: ")
+	// Read password without echoing it to the terminal
+	passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return fmt.Errorf("error reading password: %v", err)
+	}
+	fmt.Println() // Add a newline after password input
+
+	password := string(passwordBytes)
+
+	loginReq := LoginRequest{
+		Username: username,
+		Password: password,
+	}
+
+	reqBody, err := json.Marshal(loginReq)
+	if err != nil {
+		return fmt.Errorf("error preparing login request: %v", err)
+	}
+
+	resp, err := http.Post("http://localhost:8080/login", "application/json", bytes.NewBuffer(reqBody))
+	if err != nil {
+		return fmt.Errorf("login request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("login failed: %s", body)
+	}
+
+	var loginResp LoginResponse
+	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+		return fmt.Errorf("error parsing login response: %v", err)
+	}
+
+	authToken = loginResp.Token
+	fmt.Printf("Logged in as %s\n", loginResp.User.Username)
+	return nil
+}
+
+func main() {
+	fmt.Println("Welcome to the checklist client!")
+	fmt.Println("Please log in to continue.")
+
+	if err := authenticate(); err != nil {
+		fmt.Fprintf(os.Stderr, "Authentication failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+
+	for {
+		fmt.Print("$ ")
+
+		if !scanner.Scan() {
+			break
+		}
+
+		input := strings.TrimSpace(scanner.Text())
+		parts := strings.Fields(input)
+
+		if len(parts) == 0 {
+			continue
+		}
+
+		command, args := parts[0], parts[1:]
+
+		switch command {
+		case "exit":
+			code := 0
+			if len(args) > 0 {
+				if n, err := strconv.Atoi(args[0]); err == nil {
+					code = n
+				}
+			}
+			os.Exit(code)
+
+		case "views":
+			getViewCount()
+
+		default:
+			fmt.Printf("%s: command not found\n", command)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error reading input:", err)
+	}
+}
+
+func getViewCount() {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "http://localhost:8080/", nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating request: %v\n", err)
+		return
+	}
+
+	req.Header.Add("Authorization", "Bearer "+authToken)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error making request: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		fmt.Fprintf(os.Stderr, "Request failed with status %d: %s\n", resp.StatusCode, body)
+		return
+	}
+
+	var viewResp ViewCountResponse
+	if err := json.NewDecoder(resp.Body).Decode(&viewResp); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing response: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Current view count: %d\n", viewResp.Count)
+}


### PR DESCRIPTION
The shell has two commands
- `views`: Gets the number of views from the backend
- `exit`: Exits the shell

It authenticates on boot and can be started by running `go run tools/client.go` from the `backend` directory.