### PR TITLE
ci: Add checks that code is formatted and builds

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,34 @@
+name: Checklist CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  backend:
+    name: Backend Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+        cache: true
+        cache-dependency-path: 'backend/go.sum'
+    - name: Verify dependencies
+      run: go mod verify
+      working-directory: backend
+    - name: Build
+      run: go build -v ./...
+      working-directory: backend
+    - name: Format check
+      run: |
+        if [ "$(gofmt -l . | wc -l)" -gt 0 ]; then
+          echo "Go code is not formatted correctly:"
+          gofmt -d .
+          exit 1
+        fi
+      working-directory: backend


### PR DESCRIPTION
This runs `gofmt` to check the code formatting and `go build` to check that it builds on every pull request and push to `main`.

Frontend will be in a followup PR when #27 is fixed.