### PR TITLE
build: Make Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+backend/server

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: all build build-backend build-frontend clean lint format
+
+all: build
+
+build: build-backend build-frontend
+
+build-backend:
+	cd backend && go build -o server main.go
+
+build-frontend:
+	cd frontend && npm run build
+
+clean:
+	rm -f backend/server
+	rm -rf frontend/dist
+
+lint: lint-frontend
+
+lint-frontend:
+	cd frontend && npm run lint
+
+format: format-backend format-frontend
+
+format-backend:
+	cd backend/ && go fmt ./...
+
+format-frontend:
+	cd frontend && npx prettier --write .


### PR DESCRIPTION
Adds a Makefile allowing the following commands to be run from the repository root:
- `make`: Builds the backend and frontend into `backend/server` and `frontend/dist` respectively
- `make build`: Same as above
- `make build-frontend`: Builds the frontend, used by the default target
- `make build-backend`: Builds the backend, used by the default target
- `make clean`: Deletes the build output of the above
- `make lint` Lints the frontend code
- `make lint-frontend`: Runs the default linter from the Vite boilerplate with `npm run lint`
- `make format`: Formats the code
- `make format-backend`: Formats the backend code with `go fmt`
- `make format-frontend`: Formats the frontend code with `prettier`

# Testing
Ran the commands above and verified they did what they were supposed to do.