### PR TITLE
feat: Make the Postgres credentials configurable

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"database/sql"
-	"fmt"
 	"html/template"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/kujacorp/checklist/admin"
 	"github.com/kujacorp/checklist/api"
@@ -19,7 +19,10 @@ var jwtKey = []byte("your-secret-key")
 
 func init() {
 	var err error
-	dsn := fmt.Sprintf("host=postgres user=postgres password=postgres dbname=postgres sslmode=disable")
+	dsn := os.Getenv("POSTGRES_DSN")
+	if dsn == "" {
+		dsn = "host=postgres user=postgres password=postgres dbname=postgres sslmode=disable"
+	}
 	db, err = sql.Open("postgres", dsn)
 	if err != nil {
 		log.Fatal("Error connecting to database:", err)

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -38,8 +38,12 @@ server {
 }
 ```
 
-4. Thens run the backend built in step 1:
-```
+4. Set up environment variables and run the backend:
+```bash
+# Set the PostgreSQL connection string
+export POSTGRES_DSN="host=localhost user=postgres password=postgres dbname=postgres sslmode=disable"
+
+# Run the server
 /path/to/backend/server
 ```
 


### PR DESCRIPTION
Adds a `POSTGRES_DSN` environment variable which allows the DB credentials to be configurable. The Postgres docs refer to this format as ["Keyword/Value Connection Strings"](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-KEYWORD-VALUE).