### PR TITLE
docs: Add Postgres hosting info and modernize Nginx setup

### DIFF
--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -1,5 +1,12 @@
 You can host the app by building the backend and the frontend and tying them together with Nginx.
 
+# Pre-Requisites
+You will need:
+- A server with Go and Node.js installed
+- A PostgreSQL instance and its connection info (host, user, password, dbname)
+
+# Instructions
+
 1. Build the backend
 ```bash
 # From the root directory
@@ -14,7 +21,7 @@ cd frontend
 npm run build
 ```
 
-3. Create an Nginx configuration file (`/etc/nginx/sites-available/checklist.conf`):
+3. Create an Nginx configuration file (`/etc/nginx/conf.d/checklist.conf`):
 ```conf
 server {
     listen 80;
@@ -40,17 +47,15 @@ server {
 
 4. Set up environment variables and run the backend:
 ```bash
-# Set the PostgreSQL connection string
+# Set the PostgreSQL connection string, replace values with the details of your Postgres setup
 export POSTGRES_DSN="host=localhost user=postgres password=postgres dbname=postgres sslmode=disable"
 
 # Run the server
 /path/to/backend/server
 ```
 
-5. In another separate terminal, enable Nginx:
+5. In another separate terminal, restart Nginx to load the config in step 3:
 ```sh
-sudo ln -s /etc/nginx/sites-available/checklist.conf /etc/nginx/sites-enabled/
-
 # Test Nginx configuration
 sudo nginx -t
 


### PR DESCRIPTION
Clarifies that you need Postgres to host and uses `/etc/nginx/conf.d` for the Nginx configuration instead of the older `sites-available`/`sites-enabled` setup.

> The /etc/nginx/conf.d/ directory contains the default HTTP server configuration file. Files in this directory ending in .conf are included in the top-level http block from within the /etc/ nginx/nginx.conf file. It’s best practice to utilize include statements and organize your configuration in this way to keep your configuration files concise. In some package repositories, this folder is named sites-enabled, and configuration files are linked from a folder named site-available; this convention is deprecated.

Source: [The Nginx Cookbook, Chapter 1](https://www.oreilly.com/library/view/nginx-cookbook-2nd/9781098126230/)
