### PR TITLE
chore: Remove unused environment variable from Docker Compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,8 +5,6 @@ services:
       - "8080:8080"
     depends_on:
       - postgres
-    environment:
-      DATABASE_URL: "postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable"
 
   frontend:
     build: ./frontend


### PR DESCRIPTION
The `DATABASE_URL` was set but was unused all the way back in the first PR #1. We have since added the `POSTGRES_DSN` environment variable in #37 which we don't need to set since the server has it set by default to the Docker Compose's Postgres.

# Testing
Tested that the app still runs through Docker Compose.