### PR TITLE
build: Hot-reload backend

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,12 @@ services:
       - postgres
     environment:
       JWT_SECRET_KEY: "your-secret-key"
+    develop:
+      watch:
+        - action: rebuild
+          path: ./backend
+          target: /app
+
   frontend:
     build: ./frontend
     ports:


### PR DESCRIPTION
Hot reload the backend so restarting Docker Compose for development is no longer needed.

Fixes #20 