### PR TITLE
chore: Fix lint about hot reload

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { useAuth } from "./contexts/AuthContext"
+import { useAuth } from "./hooks/useAuth"
 import { Login } from "./components/Login"
 import { SignUp } from "./components/SignUp"
 

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useAuth } from '../contexts/AuthContext'
+import { useAuth } from '../hooks/useAuth'
 
 export function Login() {
   const [username, setUsername] = useState('')

--- a/frontend/src/components/SignUp.tsx
+++ b/frontend/src/components/SignUp.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useAuth } from '../contexts/AuthContext'
+import { useAuth } from '../hooks/useAuth'
 
 export function SignUp() {
   const [username, setUsername] = useState('')

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { createContext, useEffect, useState, ReactNode } from 'react'
 
 interface User {
   username: string
@@ -119,10 +119,4 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   )
 }
 
-export function useAuth() {
-  const context = useContext(AuthContext)
-  if (!context) {
-    throw new Error('useAuth must be used within an AuthProvider')
-  }
-  return context
-}
+export { AuthContext }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { AuthContext } from '../contexts/AuthContext'
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}


### PR DESCRIPTION
Was getting this lint error running `make lint`:

```
frontend/src/contexts/AuthContext.tsx
  122:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components
```

- Moves `useAuth` to its own file
- Exports `AuthContext` which is a React component instead of `useAuth` so the lint is fixed
- Updated imports to the new path for `useAuth`